### PR TITLE
Enable add-on for 100% of users, stop recording as an experiment

### DIFF
--- a/add-on/bootstrap.js
+++ b/add-on/bootstrap.js
@@ -9,15 +9,9 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Timer.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "UpdateUtils",
-  "resource://gre/modules/UpdateUtils.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "TelemetryEnvironment",
-  "resource://gre/modules/TelemetryEnvironment.jsm");
-
 // Preferences this add-on uses.
 const kPrefPrefix = "extensions.followonsearch.";
 const PREF_LOGGING = `${kPrefPrefix}logging`;
-const PREF_CHANNEL_OVERRIDE = `${kPrefPrefix}override`;
 
 const kExtensionID = "followonsearch@mozilla.com";
 const kSaveTelemetryMsg = `${kExtensionID}:save-telemetry`;
@@ -80,10 +74,6 @@ function activateTelemetry() {
 
   Services.mm.addMessageListener(kSaveTelemetryMsg, handleSaveTelemetryMsg);
   Services.mm.loadFrameScript(frameScript, true);
-
-  // Record the fact we're saving the extra data as a telemetry environment
-  // value.
-  TelemetryEnvironment.setExperimentActive(kExtensionID, "active");
 }
 
 /**
@@ -93,8 +83,6 @@ function deactivateTelemetry() {
   if (!gTelemetryActivated) {
     return;
   }
-
-  TelemetryEnvironment.setExperimentInactive(kExtensionID);
 
   Services.mm.removeMessageListener(kSaveTelemetryMsg, handleSaveTelemetryMsg);
   Services.mm.removeDelayedFrameScript(frameScript);

--- a/add-on/bootstrap.js
+++ b/add-on/bootstrap.js
@@ -14,17 +14,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "UpdateUtils",
 XPCOMUtils.defineLazyModuleGetter(this, "TelemetryEnvironment",
   "resource://gre/modules/TelemetryEnvironment.jsm");
 
-// The amount of people to be part of the telemetry reporting.
-const REPORTING_THRESHOLD = {
-  // "default": 1.0, // 100% - self builds, linux distros etc.
-  "nightly": 0.1, // 10%
-  "beta": 0.1,  // 10%
-  "release": 0.1,  // 10%
-};
-
 // Preferences this add-on uses.
 const kPrefPrefix = "extensions.followonsearch.";
-const PREF_COHORT_SAMPLE = `${kPrefPrefix}cohortSample`;
 const PREF_LOGGING = `${kPrefPrefix}logging`;
 const PREF_CHANNEL_OVERRIDE = `${kPrefPrefix}override`;
 
@@ -137,42 +128,13 @@ var cohortManager = {
     try {
       let distId = Services.prefs.getCharPref("distribution.id", "");
       if (distId) {
-        log("It is a distribution, not setting up nor enabling.");
+        log("It is a distribution, not setting up nor enabling telemetry.");
         return;
       }
     } catch (e) {}
 
-    let cohortSample;
-    try {
-      cohortSample = Services.prefs.getFloatPref(PREF_COHORT_SAMPLE, undefined);
-    } catch (e) {}
-    if (!cohortSample) {
-      cohortSample = Math.random().toString().substr(0, 8);
-      cohortSample = Services.prefs.setCharPref(PREF_COHORT_SAMPLE, cohortSample);
-    }
-    log(`Cohort Sample value is ${cohortSample}`);
-
-    let updateChannel = UpdateUtils.getUpdateChannel(false);
-    log(`Update channel is ${updateChannel}`);
-    if (!(updateChannel in REPORTING_THRESHOLD)) {
-      let prefOverride = "default";
-      try {
-        prefOverride = Services.prefs.getCharPref(PREF_CHANNEL_OVERRIDE, "default");
-      } catch (e) {}
-      if (prefOverride in REPORTING_THRESHOLD) {
-        updateChannel = prefOverride;
-      } else {
-        // Don't enable, we don't know about the channel, and it isn't overriden.
-        return;
-      }
-    }
-
-    if (cohortSample <= REPORTING_THRESHOLD[updateChannel]) {
-      log("Enabling telemetry for user");
-      this.enableForUser = true;
-    } else {
-      log("Not enabling telemetry for user - outside threshold.");
-    }
+    log("Enabling telemetry for user");
+    this.enableForUser = true;
   },
 };
 


### PR DESCRIPTION
This changes us to enable the add-on for 100% of users, except for distributions. If we need the cohort code back later, it'll be easy to drag out of history, so lets just simplify it for now.

Also stops recording as an experiment as @dzeber requested.