### PR TITLE
Bing uses FORM for searches from the suggestion dropdown

### DIFF
--- a/add-on/content/followonsearch-fs.js
+++ b/add-on/content/followonsearch-fs.js
@@ -231,9 +231,9 @@ function onPageLoad(event) {
       uri.spec == gLastSearch) {
     return;
   }
-  var queries = new URLSearchParams(doc.location.search);
+  var queries = new URLSearchParams(doc.location.search.toLowerCase());
   // For Bing, QBRE form code is used for all follow-on search
-  if (queries.get("form") != "QBRE") {
+  if (queries.get("form") != "qbre") {
     return;
   }
   if (parseCookies(doc.cookie).SRCHS == "PC=MOZI") {


### PR DESCRIPTION
I should have foreseen this. There are some edge cases where Bing uses FORM= instead of form=