### PR TITLE
Add additional yahoo domains

### DIFF
--- a/add-on/content/followonsearch-fs.js
+++ b/add-on/content/followonsearch-fs.js
@@ -35,7 +35,7 @@ let searchDomains = [{
   // The Yahoo domains to watch for.
   "domains": [
     "search.yahoo.com", "ca.search.yahoo.com", "hk.search.yahoo.com",
-    "tw.search.yahoo.com"
+    "tw.search.yahoo.com", "mozilla.search.yahoo.com", "us.search.yahoo.com"
   ],
   "search": "p",
   "followOnSearch": "fr2",


### PR DESCRIPTION
For our branded search test, Yahoo added a new domain (mozilla). They are also doing some single URL testing that involves another new domain (us).

Longer term, we probably need to revisit detecting the legacy domains and the new domains. Although once we move to single URL yahoo, things will be better.