### PR TITLE
Google removed instant search so we need to detect followon differently

### DIFF
--- a/add-on/content/followonsearch-fs.js
+++ b/add-on/content/followonsearch-fs.js
@@ -116,6 +116,7 @@ let searchDomains = [{
   ],
   "search": "q",
   "prefix": "client",
+  "followOnSearch": "oq",
   "codes": ["firefox-b-ab", "firefox-b"],
   "sap": "google",
 }];


### PR DESCRIPTION
So Google removed instant search which means follow on searches aren't indicated by hash (#) and the old search.

Now they pass a parameter called "oq"

So this has broken followon search tracking for a while.