### PR TITLE
Count any Google searches that started in Firefox

### DIFF
--- a/add-on/bootstrap.js
+++ b/add-on/bootstrap.js
@@ -59,7 +59,11 @@ function handleSaveTelemetryMsg(message) {
   log(info);
 
   let histogram = Services.telemetry.getKeyedHistogramById("SEARCH_COUNTS");
-  histogram.add(`${info.sap}.${info.type}:unknown:${info.code}`);
+  let toadd = `${info.sap}.${info.type}:unknown:${info.code}`;
+  if (info.addl) {
+    toadd += `:${info.addl}`
+  }
+  histogram.add(toadd);
 }
 
 /**

--- a/add-on/content/followonsearch-fs.js
+++ b/add-on/content/followonsearch-fs.js
@@ -205,10 +205,10 @@ var webProgressListener = {
           } else {
             let tbm = queries.get("tbm");
             if (searchingGoogle) {
-              sendSaveTelemetryMsg(code ? code : "none", tbm ? `${domainInfo.sap}-${tbm}` : domainInfo.sap, "follow-on");
+              sendSaveTelemetryMsg(code ? code : "none", domainInfo.sap, "follow-on", tbm);
             } else if (code) {
               // Trying to do the right thing for back button to existing entries
-              sendSaveTelemetryMsg(code, tbm ? `${domainInfo.sap}-${tbm}` : domainInfo.sap, "follow-on");
+              sendSaveTelemetryMsg(code, domainInfo.sap, "follow-on", tbm);
             }
           }
         }
@@ -298,11 +298,12 @@ function onPageLoad(event) {
  * @param {String} sap The SAP code.
  * @param {String} type The type of search (sap/follow-on).
  */
-function sendSaveTelemetryMsg(code, sap, type) {
+function sendSaveTelemetryMsg(code, sap, type, addl) {
   sendAsyncMessage(kSaveTelemetryMsg, {
     code,
     sap,
     type,
+    addl,
   });
 }
 

--- a/add-on/content/followonsearch-fs.js
+++ b/add-on/content/followonsearch-fs.js
@@ -144,11 +144,11 @@ function log(message) {
 // If gLastSearchQueue includes the current URL, ignore the search.
 // This also prevents us from handling reloads with hashes twice
 let gLastSearchQueue = [];
-gLastSearchQueue.push = function (){
+gLastSearchQueue.push = function(...args) {
   if (this.length >= kLastSeachQueueDepth) {
     this.shift();
   }
-  return Array.prototype.push.apply(this, arguments);
+  return Array.prototype.push.apply(this, args);
 };
 
 // Keep track of the original window we were loaded in
@@ -202,16 +202,13 @@ var webProgressListener = {
           if (queries.get("oe") && queries.get("ie")) {
             sendSaveTelemetryMsg(code ? code : "none", domainInfo.sap, "sap");
             searchingGoogle = true;
-            return;
           } else {
             let tbm = queries.get("tbm");
             if (searchingGoogle) {
-              sendSaveTelemetryMsg(code ? code : "none", tbm ? domainInfo.sap + "-" + tbm : domainInfo.sap, "follow-on");
-            } else {
+              sendSaveTelemetryMsg(code ? code : "none", tbm ? `${domainInfo.sap}-${tbm}` : domainInfo.sap, "follow-on");
+            } else if (code) {
               // Trying to do the right thing for back button to existing entries
-              if (code) {
-                sendSaveTelemetryMsg(code, tbm ? domainInfo.sap + "-" + tbm : domainInfo.sap, "follow-on");
-              }
+              sendSaveTelemetryMsg(code, tbm ? `${domainInfo.sap}-${tbm}` : domainInfo.sap, "follow-on");
             }
           }
         }

--- a/add-on/content/followonsearch-fs.js
+++ b/add-on/content/followonsearch-fs.js
@@ -175,10 +175,14 @@ var webProgressListener = {
           // Not a URL
           (!aLocation.schemeIs("http") && !aLocation.schemeIs("https")) ||
           // Doesn't have a query string or a ref
-          (!aLocation.query && !aLocation.ref) ||
-          // Is the same as our last search (avoids reloads)
-          gLastSearchQueue.includes(aLocation.spec)) {
+          (!aLocation.query && !aLocation.ref)) {
         searchingGoogle = false;
+        return;
+      }
+      if (gLastSearchQueue.includes(aLocation.spec)) {
+        // If it's a recent search, just return. We
+        // don't reset searchingGoogle though because
+        // we might still be doing that.
         return;
       }
       let domainInfo = getSearchDomainCodes(aLocation.host);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "multiprocess": true
   },
   "scripts": {
-    "bundle": "mkdir -p dist && cd add-on && zip -r -x .eslintrc -D -q ../dist/followonsearch.xpi . && cd ..",
+    "bundle": "mkdir -p dist && cd add-on && zip -r -x .eslintrc.js -D -q ../dist/followonsearch.xpi . && cd ..",
     "download": "node scripts/get_ff.js",
     "firefox": "scripts/runfx.js --binary ${FIREFOX_BINARY:-nightly} --profile dev",
     "lint": "npm-run-all lint:*",


### PR DESCRIPTION
@Standard8 This adds support for counting all Google searches that start in Firefox.

It also adds differentiation for images/video/news/books.

It also switches to using a queue for managing recent searches so we don't end up with too many duplicates if someone goes back and forward a lot. I'm currently capping at 10 searches (not 10 pages)