### PR TITLE
Update Google to count no code searches and vertical searches

### DIFF
--- a/add-on/bootstrap.js
+++ b/add-on/bootstrap.js
@@ -59,7 +59,11 @@ function handleSaveTelemetryMsg(message) {
   log(info);
 
   let histogram = Services.telemetry.getKeyedHistogramById("SEARCH_COUNTS");
-  histogram.add(`${info.sap}.${info.type}:unknown:${info.code}`);
+  let payload = `${info.sap}.${info.type}:unknown:${info.code}`;
+  if (info.extra) {
+    payload += `:${info.extra}`
+  }
+  histogram.add(payload);
 }
 
 /**

--- a/add-on/content/followonsearch-fs.js
+++ b/add-on/content/followonsearch-fs.js
@@ -13,6 +13,7 @@ Cu.importGlobalProperties(["URLSearchParams"]);
 const kExtensionID = "followonsearch@mozilla.com";
 const kSaveTelemetryMsg = `${kExtensionID}:save-telemetry`;
 const kShutdownMsg = `${kExtensionID}:shutdown`;
+const kLastSearchQueueDepth = 10;
 
 /**
  * A map of search domains with their expected codes.
@@ -139,14 +140,24 @@ function log(message) {
   // console.log(message);
 }
 
-// Hack to handle the most common reload case.
-// If gLastSearch is the same as the current URL, ignore the search.
+// Hack to handle the most common reload/back/forward case.
+// If gLastSearchQueue includes the current URL, ignore the search.
 // This also prevents us from handling reloads with hashes twice
-let gLastSearch = null;
+let gLastSearchQueue = [];
+gLastSearchQueue.push = function(...args) {
+  if (this.length >= kLastSearchQueueDepth) {
+    this.shift();
+  }
+  return Array.prototype.push.apply(this, args);
+};
 
 // Keep track of the original window we were loaded in
 // so we don't handle requests for other windows.
 let gOriginalWindow = null;
+
+// Track if we are in the middle of a Google session
+// that started from Firefox
+let searchingGoogle = false;
 
 /**
  * Since most codes are in the URL, we can handle them via
@@ -164,35 +175,62 @@ var webProgressListener = {
           // Not a URL
           (!aLocation.schemeIs("http") && !aLocation.schemeIs("https")) ||
           // Doesn't have a query string or a ref
-          (!aLocation.query && !aLocation.ref) ||
-          // Is the same as our last search (avoids reloads)
-          aLocation.spec == gLastSearch) {
+          (!aLocation.query && !aLocation.ref)) {
+        searchingGoogle = false;
+        return;
+      }
+      if (gLastSearchQueue.includes(aLocation.spec)) {
+        // If it's a recent search, just return. We
+        // don't reset searchingGoogle though because
+        // we might still be doing that.
         return;
       }
       let domainInfo = getSearchDomainCodes(aLocation.host);
       if (!domainInfo) {
+        searchingGoogle = false;
         return;
       }
 
       let queries = new URLSearchParams(aLocation.query);
       let code = queries.get(domainInfo.prefix);
+      // Special case Google so we can track searches
+      // without codes from the browser.
+      if (domainInfo.sap == "google") {
+        if (aLocation.filePath == "/search") {
+          gLastSearchQueue.push(aLocation.spec);
+          // Our engine currently sends oe and ie - no one else does
+          if (queries.get("oe") && queries.get("ie")) {
+            sendSaveTelemetryMsg(code ? code : "none", domainInfo.sap, "sap");
+            searchingGoogle = true;
+          } else {
+            let tbm = queries.get("tbm");
+            if (searchingGoogle) {
+              sendSaveTelemetryMsg(code ? code : "none", domainInfo.sap, "follow-on", tbm ? `vertical-${tbm}` : null);
+            } else if (code) {
+              // Trying to do the right thing for back button to existing entries
+              sendSaveTelemetryMsg(code, domainInfo.sap, "follow-on", tbm ? `vertical-${tbm}` : null);
+            }
+          }
+        }
+        // Special case all Google. Otherwise our code can
+        // show up in maps
+        return;
+      }
+      searchingGoogle = false;
       if (queries.get(domainInfo.search)) {
         if (domainInfo.codes.includes(code)) {
           if (domainInfo.reportPrefix &&
               queries.get(domainInfo.reportPrefix)) {
             code = queries.get(domainInfo.reportPrefix);
           }
-          if (domainInfo.sap == "google" && aLocation.ref) {
-            log(`${aLocation.host} search with code ${code} - Follow on`);
-            sendSaveTelemetryMsg(code, domainInfo.sap, "follow-on");
-          } else if (queries.get(domainInfo.followOnSearch)) {
+          if (queries.get(domainInfo.followOnSearch)) {
             log(`${aLocation.host} search with code ${code} - Follow on`);
             sendSaveTelemetryMsg(code, domainInfo.sap, "follow-on");
           } else {
             log(`${aLocation.host} search with code ${code} - First search via Firefox`);
             sendSaveTelemetryMsg(code, domainInfo.sap, "sap");
           }
-          gLastSearch = aLocation.spec;
+          gLastSearchQueue.push(aLocation.spec);
         }
       }
     } catch (e) {
@@ -236,7 +274,7 @@ function onPageLoad(event) {
       (!uri.schemeIs("http") && !uri.schemeIs("https")) ||
        uri.host != "www.bing.com" ||
       !doc.location.search ||
-      uri.spec == gLastSearch) {
+      gLastSearchQueue.includes(uri.spec)) {
     return;
   }
   var queries = new URLSearchParams(doc.location.search.toLowerCase());
@@ -247,7 +285,7 @@ function onPageLoad(event) {
   if (parseCookies(doc.cookie).SRCHS == "PC=MOZI") {
     log(`${uri.host} search with code MOZI - Follow on`);
     sendSaveTelemetryMsg("MOZI", "bing", "follow-on");
-    gLastSearch = uri.spec;
+    gLastSearchQueue.push(uri.spec);
   }
 }
 
@@ -258,12 +296,14 @@ function onPageLoad(event) {
  * @param {String} code The codes used for the search engine.
  * @param {String} sap The SAP code.
  * @param {String} type The type of search (sap/follow-on).
+ * @param {String} extra Any additional parameters (Optional)
  */
-function sendSaveTelemetryMsg(code, sap, type) {
+function sendSaveTelemetryMsg(code, sap, type, extra) {
   sendAsyncMessage(kSaveTelemetryMsg, {
     code,
     sap,
     type,
+    extra,
   });
 }
 

--- a/add-on/content/followonsearch-fs.js
+++ b/add-on/content/followonsearch-fs.js
@@ -203,6 +203,8 @@ var webProgressListener = {
             sendSaveTelemetryMsg(code ? code : "none", domainInfo.sap, "sap");
             searchingGoogle = true;
           } else {
+            // The tbm value is the specific type of search (Books, Images, News, etc).
+            // These are referred to as vertical searches.
             let tbm = queries.get("tbm");
             if (searchingGoogle) {
               sendSaveTelemetryMsg(code ? code : "none", domainInfo.sap, "follow-on", tbm ? `vertical-${tbm}` : null);


### PR DESCRIPTION
This patch allows us to count Google searches that don't have a code if they originate from Firefox search access points. I also added an additional parameter so we can tell if something is from one of the Google vertical searches.