### PR TITLE
Docs - README.md - adding thumbnail logo & ToC header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@ Firefox Follow-on Search Telemetry.
 
 # Documentation
 
+### Table of Contents (ToC)
+
 * [Building, running code and tests](docs/Developing.md)
 * [Metrics](docs/METRICS.md)
 * Testing
   * [Linting](docs/Linting.md)
   * [Unit Tests](docs/UnitTests.md)
   * [Functional Tests](docs/Functional.md)
+
+---
+
+<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4" width="50"></img>


### PR DESCRIPTION
## Docs - README.md - adding thumbnail logo & ToC header

**this PR does basically aim at:**
- *adding thumbnail logo & ToC header;*

---

**main motivation is to:**
- *improving accessibility of README.md file* 
- *increase in a small scale the chances of receiving further commits, issues and PRs*

---

<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4" width="50"></img> <img src="https://avatars1.githubusercontent.com/u/7303598?s=460&v=4" width="50"></img>
