### PR TITLE
Update ESLint node modules, add mochitest to source

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+# See http://pep8.readthedocs.io/en/latest/intro.html#configuration
+ignore = E722

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ Firefox Follow-on Search Telemetry.
 * Testing
   * [Linting](docs/Linting.md)
   * [Unit Tests](docs/UnitTests.md)
+  * [Mochitests](docs/Mochitests.md)
   * [Functional Tests](docs/Functional.md)

--- a/add-on/bootstrap.js
+++ b/add-on/bootstrap.js
@@ -6,13 +6,12 @@
 
 /* global APP_STARTUP, APP_SHUTDOWN */
 
-const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Timer.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "Services",
-                                  "resource://gre/modules/Services.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "LegacyExtensionsUtils",
-                                  "resource://gre/modules/LegacyExtensionsUtils.jsm");
+ChromeUtils.defineModuleGetter(this, "LegacyExtensionsUtils",
+                               "resource://gre/modules/LegacyExtensionsUtils.jsm");
 
 // Preferences this add-on uses.
 const kPrefPrefix = "extensions.followonsearch.";

--- a/docs/Mochitests.md
+++ b/docs/Mochitests.md
@@ -1,0 +1,20 @@
+# Mochitests
+
+[Mochitest](https://developer.mozilla.org/en-US/docs/Mozilla/Browser_chrome_tests)
+is a special kind of framework designed to run in the browser window.
+
+# Test Files
+
+The test files live in the `test/mochitest/` directory.
+
+# Running the Tests
+
+You have to first export repository to a mozilla-central based repository, and
+then run the tests from there.
+
+See [exporting to mozilla-central](Exporting.md) for how to export.
+
+```shell
+$ ./mach build
+$ ./mach mochitest browser/extensions/followonsearch/
+```

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
   "dependencies": {},
   "devDependencies": {
     "commander": "2.9.0",
-    "eslint": "3.19.0",
+    "eslint": "4.19.1",
     "eslint-plugin-json": "1.2.0",
-    "eslint-plugin-mocha": "4.9.0",
-    "eslint-plugin-mozilla": "0.3.2",
-    "eslint-plugin-promise": "3.5.0",
+    "eslint-plugin-mocha": "5.0.0",
+    "eslint-plugin-mozilla": "0.10.0",
+    "eslint-plugin-no-unsanitized": "3.0.0",
+    "eslint-plugin-promise": "3.7.0",
     "fx-runner": "1.0.6",
     "geckodriver": "1.6.1",
     "jpm": "1.3.1",
@@ -31,9 +32,9 @@
     "karma-mocha-reporter": "2.2.3",
     "mocha": "3.4.2",
     "mz": "2.6.0",
-    "sinon": "2.3.2",
     "npm-run-all": "4.0.2",
     "selenium-webdriver": "3.4.0",
+    "sinon": "2.3.2",
     "virtualenv": "0.3.1"
   },
   "permissions": {

--- a/scripts/export_mc.py
+++ b/scripts/export_mc.py
@@ -87,7 +87,7 @@ def exportFilesToMC(repoDir, mcRepoLoc):
                 os.remove(os.path.join(root, file))
 
     addonDir = os.path.join(repoDir, "add-on")
-    # testDir = os.path.join(repoDir, "test", "addon")
+    testDir = os.path.join(repoDir, "test", "mochitest")
     # enUSFile = os.path.join(addonDir, "webextension", "_locales", "en_US",
     #                        "messages.json")
 
@@ -112,15 +112,15 @@ def exportFilesToMC(repoDir, mcRepoLoc):
                 os.mkdir(dirPath, 0755)
 
     # Copy the test files.
-    # mc_test_loc = os.path.join(mcRepoLoc, "test", "browser")
-    # if not os.path.exists(mc_test_loc):
-    #    os.makedirs(mc_test_loc, 0755)
+    mc_test_loc = os.path.join(mcRepoLoc, "test", "browser")
+    if not os.path.exists(mc_test_loc):
+        os.makedirs(mc_test_loc, 0755)
 
-    # for root, dirs, files in os.walk(testDir):
-        # for file in files:
-        #     copyfile(os.path.join(root, file),
-        #              os.path.join(mc_test_loc, os.path.relpath(root, testDir),
-        #              file))
+    for root, dirs, files in os.walk(testDir):
+        for file in files:
+            copyfile(os.path.join(root, file),
+                     os.path.join(mc_test_loc, os.path.relpath(root, testDir),
+                     file))
 
     # Finally, update the moz.build file.
     # runProcess([".venv/bin/python", "bin/update_mozbuild.py"], repoDir,

--- a/test/mochitest/.eslintrc.js
+++ b/test/mochitest/.eslintrc.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+  "extends": [
+    "plugin:mozilla/browser-test",
+  ],
+};

--- a/test/mochitest/browser.ini
+++ b/test/mochitest/browser.ini
@@ -1,0 +1,7 @@
+[DEFAULT]
+
+[browser_followOnTelemetry.js]
+support-files =
+  test.html
+  test2.html
+  testEngine.xml

--- a/test/mochitest/browser_followOnTelemetry.js
+++ b/test/mochitest/browser_followOnTelemetry.js
@@ -1,0 +1,66 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+ChromeUtils.defineModuleGetter(this, "SearchTestUtils",
+  "resource://testing-common/SearchTestUtils.jsm");
+
+SearchTestUtils.init(Assert, registerCleanupFunction);
+
+const BASE_URL = "http://mochi.test:8888/browser/browser/extensions/followonsearch/test/browser/";
+const TEST_ENGINE_BASENAME = "testEngine.xml";
+
+add_task(async function test_followOnSearchTelemetry() {
+  let engine = await SearchTestUtils.promiseNewSearchEngine(
+    getRootDirectory(gTestPath) + TEST_ENGINE_BASENAME,
+    registerCleanupFunction);
+  let oldCurrentEngine = Services.search.currentEngine;
+  Services.search.currentEngine = engine;
+
+  let histogram = Services.telemetry.getKeyedHistogramById("SEARCH_COUNTS");
+  histogram.clear();
+
+  registerCleanupFunction(() => Services.search.currentEngine = oldCurrentEngine);
+
+  await BrowserTestUtils.withNewTab({gBrowser}, async browser => {
+    // Open the initial search page via entering a search on the URL bar.
+    let loadPromise = BrowserTestUtils.waitForLocationChange(gBrowser,
+      `${BASE_URL}test.html?searchm=test&mt=TEST`);
+
+    gURLBar.focus();
+    EventUtils.sendString("test");
+    EventUtils.sendKey("return");
+
+    await loadPromise;
+
+    // Perform a follow-on search, selecting the form in the page.
+    loadPromise = BrowserTestUtils.waitForLocationChange(gBrowser,
+      `${BASE_URL}test2.html?mtfo=followonsearchtest&mt=TEST&m=test`);
+
+    await ContentTask.spawn(browser, null, function() {
+      content.document.getElementById("submit").click();
+    });
+
+    await loadPromise;
+
+    let snapshot;
+
+    // We have to wait for the snapshot to come in, as there's async functionality
+    // in the extension.
+    await TestUtils.waitForCondition(() => {
+      snapshot = histogram.snapshot();
+      return "mochitest.follow-on:unknown:TEST" in snapshot;
+    });
+    Assert.ok("mochitest.follow-on:unknown:TEST" in snapshot,
+      "Histogram should have an entry for the follow-on search.");
+    Assert.deepEqual(snapshot["mochitest.follow-on:unknown:TEST"], {
+      counts: [ 1, 0, 0 ],
+      histogram_type: 4,
+      max: 2,
+      min: 1,
+      ranges: [ 0, 1, 2 ],
+      sum: 1,
+    }, "Histogram should have the correct snapshot data");
+  });
+});

--- a/test/mochitest/test.html
+++ b/test/mochitest/test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Follow-on Search Test</title>
+</head>
+<body>
+  <form method="get" action="test2.html">
+    <input type="text" name="mtfo" value="followonsearchtest"/>
+    <input type="text" name="mt" value="TEST"/>
+    <input type="text" name="m" value="test"/>
+    <input type="submit" id="submit" value="submit"/>
+  </form>
+</body>
+</html>

--- a/test/mochitest/test2.html
+++ b/test/mochitest/test2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Follow-on Search Test Final Page</title>
+</head>
+<body></body>
+</html>

--- a/test/mochitest/testEngine.xml
+++ b/test/mochitest/testEngine.xml
@@ -1,0 +1,15 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Mochitest</ShortName>
+  <Description>Mochitest Engine</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABGklEQVQoz2NgGB6AnZ1dUlJSXl4eSDIyMhLW4Ovr%2B%2Fr168uXL69Zs4YoG%2BLi4i5dusTExMTGxsbNzd3f37937976%2BnpmZmagbHR09J49e5YvX66kpATVEBYW9ubNm2nTphkbG7e2tp44cQLIuHfvXm5urpaWFlDKysqqu7v73LlzECMYIiIiHj58mJCQoKKicvXq1bS0NKBgW1vbjh074uPjgeqAXE1NzSdPnvDz84M0AEUvXLgAsW379u1z5swBen3jxo2zZ892cHB4%2BvQp0KlAfwI1cHJyghQFBwfv2rULokFXV%2FfixYu7d%2B8GGqGgoMDKyrpu3br9%2B%2FcDuXl5eVA%2FAEWBfoWHAdAYoNuAYQ0XAeoUERFhGDYAAPoUaT2dfWJuAAAAAElFTkSuQmCC</Image>
+  <Url type="text/html" method="GET" template="http://mochi.test:8888/browser/browser/extensions/followonsearch/test/browser/test.html?search" rel="searchform">
+    <Param name="m" value="{searchTerms}"/>
+    <Param name="mt" value="TEST"/>
+  </Url>
+</OpenSearchDescription>


### PR DESCRIPTION
Mike, I've adding the mochitest here, so it doesn't get totally forgotten when we do updates. It also gets linted here, rather than in m-c, so I think it makes reasonable sense to have the file in this repo as well. One day we might have the capability to do different styles of tests in m-c or have mochitests run easily from github repos...